### PR TITLE
Initializing README - move of repo to ISC org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# For further syntax options see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, # these users
+# will be requested for review when someone opens a pull request.
+*       @3cpt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# repo-score-py
+# repo-activity-score
+
+The goal of this repository is to collect reference implementations of the [Repository Activity Score](https://patterns.innersourcecommons.org/p/repository-activity-score).
+
+Currently we got only a single implementation (in Python), but are considering to add similar versions for JavaScript, Go and C#. Feel free to contribute other implementations! :)
+
+## How to run this
+
+TBD: how to run the current implementation
+
+## Limitations
+
+These implementations assume that the repositories for which you want to calculate the Repository Activity Score are hosted in GitHub i.e. the respective metadata is available via the GitHub Search API and GitHub stats/participation API.
+
+However it should be possible with relatively low effort to adapt these implementations to other version control systems.
+
+## Educational purposes only
+
+These implementations are provided as reference implementations and with that for educational purposes only.
+
+## License
+
+[MIT License](LICENSE). 


### PR DESCRIPTION
After moving this repo to the InnerSourceCommons org, I am adding a basic README describing the purpose of this repo.

Also added an initial CODEOWNERS, to clearly mark @3cpt as the main contact for this.